### PR TITLE
chore: documentation example code was not secure

### DIFF
--- a/Documentation/Modules/IO.md
+++ b/Documentation/Modules/IO.md
@@ -144,7 +144,8 @@ function fs_write(path, content) {
 }
 
 io.mkdir("test", S_IRUSR | S_IWUSR);
-fs_write("test/file", "meow!");
-print(fs_read("test/file"));
+let fd = io.open("test/file", O_RDWR | O_NOFOLLOW); //O_NOFOLLOW ensures that even if someone replaces test with a symlink in between, open() will fail on symlinks and not follow them.
+io.write(fd, "meow!", 5);
+print(io.read(fd, 4));
 io.remove("test/file");
 ```

--- a/Documentation/Modules/IO.md
+++ b/Documentation/Modules/IO.md
@@ -146,6 +146,6 @@ function fs_write(path, content) {
 io.mkdir("test", S_IRUSR | S_IWUSR);
 let fd = io.open("test/file", O_RDWR | O_NOFOLLOW); //O_NOFOLLOW ensures that even if someone replaces test with a symlink in between, open() will fail on symlinks and not follow them.
 io.write(fd, "meow!", 5);
-print(io.read(fd, 4));
+print(io.read(fd, 5));
 io.remove("test/file");
 ```

--- a/Documentation/Modules/IO.md
+++ b/Documentation/Modules/IO.md
@@ -147,5 +147,6 @@ io.mkdir("test", S_IRUSR | S_IWUSR);
 let fd = io.open("test/file", O_RDWR | O_NOFOLLOW); //O_NOFOLLOW ensures that even if someone replaces test with a symlink in between, open() will fail on symlinks and not follow them.
 io.write(fd, "meow!", 5);
 print(io.read(fd, 5));
+io.close(fd);
 io.remove("test/file");
 ```


### PR DESCRIPTION
The example code shown was not secure. While this is not a vulnerability since it is not used as actual code, developers should not be given unsafe code as documentation and expect it to be the norm. This PR fixes it to be secure of TOCTOU race conditions, as before it would have been possible to, after io.mkdir(), another process quickly changes the directory to be a symlink, granting the arbitrary process to abuse the following fs_write() call to make the Nyxian example code write to any file it wants to.