### PR TITLE
fix: check read() read entire buffer size

### DIFF
--- a/Nyxian/Runtime/Modules/IO/IO.m
+++ b/Nyxian/Runtime/Modules/IO/IO.m
@@ -236,12 +236,12 @@ char* readline(const char *prompt);
         return JS_THROW_ERROR(EW_NULL_POINTER);
     
     ssize_t bytesRead = read(fd, rw_buffer, size);
-    
-    if (bytesRead < 0)
-        return JS_THROW_ERROR(EW_UNEXPECTED);
-    
+
     if (bytesRead == 0)
         return NULL;
+        
+    if (bytesRead < size)
+        return JS_THROW_ERROR(EW_UNEXPECTED);
     
     NSData *resultData = [NSData dataWithBytes:rw_buffer length:bytesRead];
     


### PR DESCRIPTION
The following fix is to fix a security issue in which if read() is called and a process modifies the file at the same time to finish early, there will be end bytes of the buffer that read() did not copy to or 0 out, thus disclosing process memory. Some systems do 0 out on malloc() nowadays, but this is not all systems (and is not a true fix for this) so I am PRing this patch.

Apologies for not reporting privately, but at the time of PR there is no private security reporting enabled.