### PR TITLE
fix: switch rw_buffer to stack, not heap

### DIFF
--- a/Nyxian/Runtime/Modules/IO/IO.m
+++ b/Nyxian/Runtime/Modules/IO/IO.m
@@ -569,24 +569,19 @@ char* readline(const char *prompt);
 - (id)getcwd:(UInt64)size
 {
     if(size == 0)
-        size = 2048;
+        size = 2048; //TODO: In future use PATH_MAX instead of just assuming it is 2048, not too much of an issue though since getcwd() already checks for us
     
-    char *rw_buffer = malloc(size);
+    char rw_buffer[2048];
     
     if(rw_buffer == NULL)
         return JS_THROW_ERROR(EW_NULL_POINTER);
     
     if(getcwd(rw_buffer, size) == NULL)
     {
-        free(rw_buffer);
         return JS_THROW_ERROR(EW_NULL_POINTER);
     }
     
-    NSString *buffer = @(rw_buffer);
-    
-    free(rw_buffer);
-    
-    return buffer;
+    return @(rw_buffer);
 }
 
 @end


### PR DESCRIPTION
Instead of using malloc(), I changed getcwd to have the rw_buffer be on the stack and not dynamically allocated to ensure better performance and memory usage.