### PR TITLE
fix: use NSString's length property instead of strlen()

### DIFF
--- a/Nyxian/Runtime/Modules/IO/IO.m
+++ b/Nyxian/Runtime/Modules/IO/IO.m
@@ -214,7 +214,7 @@ char* readline(const char *prompt);
     
     const char *buffer = [text UTF8String];
     
-    if(strlen(buffer) < size)
+    if(text.length < size)
         return JS_THROW_ERROR(EW_OUT_OF_BOUNDS);
     
     ssize_t bytesWritten = write(fd, buffer, size);


### PR DESCRIPTION
Ok, so first off write:text:size: should NOT be NSString. Developers may want to write buffers that are not strings to files, I believe it should be a buffer or NSData for use case. But, if you do need to use NSString, you should actually be taking advantage of it and be using the length property rather than calling strlen() on the result. This ensures that if there are any NULL bytes in the string it will not end early, and overall is just better for the codebase.