### PR TITLE
Fix icon missing issue on iOS 17

### DIFF
--- a/Nyxian/UI/FileList/FileList.swift
+++ b/Nyxian/UI/FileList/FileList.swift
@@ -418,7 +418,7 @@ import UniformTypeIdentifiers
             guard let self = self else { return UIMenu() }
             
             let copyAction = UIAction(title: "Copy", image: UIImage(systemName: {
-                if #available(iOS 17.0, *) {
+                if #available(iOS 18.0, *) {
                     return "document.on.clipboard"
                 } else {
                     return "doc.on.doc.fill"

--- a/Nyxian/UI/Settings/ApplicationManagement.swift
+++ b/Nyxian/UI/Settings/ApplicationManagement.swift
@@ -238,7 +238,13 @@ class ApplicationManagementViewController: UIThemedTableViewController, UITextFi
                 self.present(navMachOViewController, animated: true)
             }
             
-            let clearContainerAction = UIAction(title: "Clear Data Container", image: UIImage(systemName: "arrow.up.trash.fill")) { _ in
+            let clearContainerAction = UIAction(title: "Clear Data Container", image: UIImage(systemName: {
+                if #available(iOS 17.0, *) {
+                    return "arrow.up.trash.fill"
+                } else {
+                    return "trash.fill"
+                }
+            }())) { _ in
                 guard let application = application else { return }
                 PEProcessManager.shared().closeIfRunning(usingBundleIdentifier: application.bundleIdentifier)
                 LDEApplicationWorkspace.shared().clearContainer(forBundleID: application.bundleIdentifier)

--- a/Nyxian/UI/Settings/SettingsViewController.swift
+++ b/Nyxian/UI/Settings/SettingsViewController.swift
@@ -65,7 +65,7 @@ class SettingsViewController: UIThemedTableViewController {
             break
         case 3:
             cell.imageView?.image = UIImage(systemName: {
-                if #available(iOS 17.0, *) {
+                if #available(iOS 18.0, *) {
                     return "checkmark.seal.text.page.fill"
                 } else {
                     return "checkmark.seal.fill"

--- a/Nyxian/UI/TableCells/FileListCell.swift
+++ b/Nyxian/UI/TableCells/FileListCell.swift
@@ -89,7 +89,7 @@ class FileIcon: UIView {
             case "png", "jpg", "jpeg", "gif", "svg":
                 configureImageIcon(name: "photo.fill")
             default:
-                if #unavailable(iOS 17.0) {
+                if #unavailable(iOS 18.0) {
                     configureImageIcon(name: "text.alignleft")
                 } else {
                     configureImageIcon(name: "text.page.fill")


### PR DESCRIPTION
Close #65 

Source:

<img width="1312" height="912" alt="SF" src="https://github.com/user-attachments/assets/2ae617e8-f985-4332-927a-d5bc89acdfda" />

checkmark.seal.text.page.fill is only available on SF 6.0+ which is iOS 18+