### PR TITLE
Fix template picker contrast in dark mode

### DIFF
--- a/Nyxian/UI/ProjectCreationSheetView.swift
+++ b/Nyxian/UI/ProjectCreationSheetView.swift
@@ -86,10 +86,35 @@ struct ProjectCreationSheetView: View {
                     onCreate()
                 }
             }
-            .buttonStyle(.borderedProminent)
+            .buttonStyle(ProjectCreationPrimaryButtonStyle())
         }
         .controlSize(.large)
         .padding(.horizontal, 20)
         .padding(.vertical, 16)
+    }
+}
+
+private struct ProjectCreationPrimaryButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.body.weight(.semibold))
+            .padding(.horizontal, 22)
+            .frame(minHeight: 44)
+            .foregroundStyle(Color(uiColor: .systemBackground))
+            .background {
+                Capsule(style: .continuous)
+                    .fill(Color(uiColor: .label))
+                    .opacity(buttonOpacity(isPressed: configuration.isPressed))
+            }
+    }
+
+    private func buttonOpacity(isPressed: Bool) -> Double {
+        if !isEnabled {
+            return 0.25
+        }
+
+        return isPressed ? 0.72 : 1
     }
 }

--- a/Nyxian/UI/ProjectTemplateSelectionView.swift
+++ b/Nyxian/UI/ProjectTemplateSelectionView.swift
@@ -24,6 +24,18 @@ import SwiftUI
 struct ProjectTemplateSelectionView: View {
     @ObservedObject var model: ProjectTemplateOptionsModel
 
+    private var selectedAccentColor: Color {
+        Color(uiColor: .label)
+    }
+
+    private var selectedIconForegroundColor: Color {
+        Color(uiColor: .systemBackground)
+    }
+
+    private var unselectedIconForegroundColor: Color {
+        Color(uiColor: .secondaryLabel)
+    }
+
     var body: some View {
         VStack(spacing: 8) {
             templateRow(
@@ -58,10 +70,11 @@ struct ProjectTemplateSelectionView: View {
             HStack(spacing: 12) {
                 ZStack {
                     RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .fill(isSelected ? Color.accentColor : Color(uiColor: .tertiarySystemFill))
+                        .fill(isSelected ? selectedAccentColor : Color(uiColor: .tertiarySystemFill))
                     Image(systemName: systemImage)
                         .font(.system(size: 22, weight: .semibold))
-                        .foregroundStyle(isSelected ? Color.white : Color.accentColor)
+                        .symbolRenderingMode(.monochrome)
+                        .foregroundStyle(isSelected ? selectedIconForegroundColor : unselectedIconForegroundColor)
                 }
                 .frame(width: 42, height: 42)
 
@@ -78,7 +91,7 @@ struct ProjectTemplateSelectionView: View {
 
                 Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                     .font(.system(size: 20, weight: .semibold))
-                    .foregroundStyle(isSelected ? Color.accentColor : Color(uiColor: .tertiaryLabel))
+                    .foregroundStyle(isSelected ? selectedAccentColor : Color(uiColor: .tertiaryLabel))
             }
             .padding(10)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -86,7 +99,7 @@ struct ProjectTemplateSelectionView: View {
             .clipShape(RoundedRectangle(cornerRadius: 13, style: .continuous))
             .overlay {
                 RoundedRectangle(cornerRadius: 13, style: .continuous)
-                    .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 1.5)
+                    .stroke(isSelected ? selectedAccentColor : Color.clear, lineWidth: 1.5)
             }
         }
         .buttonStyle(.plain)


### PR DESCRIPTION
## Summary
- Replace accent-tinted selected template controls with adaptive label/background colors.
- Add a custom primary button style so the Next/Create button remains readable in dark mode.
- Keep selected template icon, border, and checkmark contrast consistent across light and dark appearances.

## Old behavior

<img width="1366" height="1024" alt="IMG_0489" src="https://github.com/user-attachments/assets/ae483c66-bb17-4245-aa51-d8d2ec59502a" />

## New behavior

<img width="1366" height="1024" alt="IMG_0491" src="https://github.com/user-attachments/assets/2ded2873-7163-4922-9a86-66e7c5178062" />

<img width="1366" height="1024" alt="IMG_0492" src="https://github.com/user-attachments/assets/dc36e0bb-6a56-43e5-8970-bfbfbc4fe081" />
