### PR TITLE
Fix project creation footer button wrapping

### DIFF
--- a/Nyxian/UI/ProjectCreationSheetView.swift
+++ b/Nyxian/UI/ProjectCreationSheetView.swift
@@ -102,7 +102,9 @@ private struct ProjectCreationPrimaryButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.body.weight(.semibold))
-            .padding(.horizontal, 22)
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+            .padding(.horizontal, 18)
             .frame(minHeight: 44)
             .foregroundStyle(Color(uiColor: currentTheme!.backgroundColor))
             .background {
@@ -127,7 +129,9 @@ private struct ProjectCreationSecondaryButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.body.weight(.semibold))
-            .padding(.horizontal, 22)
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+            .padding(.horizontal, 18)
             .frame(minHeight: 44)
             .foregroundStyle(Color(uiColor: currentTheme!.textColor))
             .background {


### PR DESCRIPTION
## Summary
- Keep project creation footer button labels on one line.
- Preserve the custom themed button style while preventing the `Previous` label from hyphen-wrapping.
- Slightly reduce horizontal button padding so the three-button footer has enough room on iPhone-width sheets.

## Root Cause
Commit `44c833e95ef225dc43411764533fe2ea30cdce98` replaced the system `.bordered` button style with custom themed button styles. The custom styles did not constrain labels to one line or preserve their intrinsic width, so SwiftUI could compress the middle footer button and wrap `Previous` as `Previ-` / `ous`.

## Screenshots
Before:
<img width="590" height="1278" alt="before" src="https://github.com/user-attachments/assets/4acff7cb-4fc6-4a74-815b-a537a9d7dfad" />

After:
<img width="590" height="1278" alt="after" src="https://github.com/user-attachments/assets/6ac92b59-04ae-4a40-b9bc-2416a47820ea" />